### PR TITLE
Filter crank markers before event detection

### DIFF
--- a/cycling.calqulus.yaml
+++ b/cycling.calqulus.yaml
@@ -30,8 +30,8 @@
   where:
     name: Cycling*
   steps:
-    - marker: L_crank => L_spindle
-    - marker: R_crank => R_spindle
+    - import: L_crank_filtered => L_spindle
+    - import: R_crank_filtered => R_spindle
     - concatenate: [L_spindle, R_spindle]
     - mean:
       output: Bottom_Bracket_temp
@@ -435,6 +435,23 @@
 #-----------------
 # for now we allow to put crank marker only at opposite side of crank in respect to pedal (near axis)
 
+# Filter crank markers
+- marker: L_crank_filtered
+  steps:
+    - marker: L_crank
+    - lowpass: $prev
+      order: 2
+      cutoff: 10
+      extrapolate: 100
+
+- marker: R_crank_filtered
+  steps:
+    - marker: R_crank
+    - lowpass: $prev
+      order: 2
+      cutoff: 10
+      extrapolate: 100
+
 # Left crank angle
 - event: L_TDC_Temp
   where:
@@ -458,7 +475,7 @@
     name: Cycling*
   set: left
   steps:
-    - marker: L_crank
+    - import: L_crank_filtered
       space: VirtualLab
     - convert:
       from: mm
@@ -524,7 +541,7 @@
     name: Cycling*
   set: right
   steps:
-    - marker: R_crank
+    - import: R_crank_filtered
       space: VirtualLab
     - convert:
       from: mm


### PR DESCRIPTION
The crank markers are a bit noisy and need to be filtered to avoid bad event detection
A butterworth filter does the trick