### PR TITLE
Field access syntax - semicolons

### DIFF
--- a/baseball-pitching.calqulus.yaml
+++ b/baseball-pitching.calqulus.yaml
@@ -956,19 +956,19 @@
   where:
     name: Pitching*
   steps:
-    - import: $field(Ball speed, measurement, numeric)
+    - import: $field(Ball speed; measurement; numeric)
 
 - parameter: SPIN_RATE
   where:
     name: Pitching*
   steps:
-    - import: $field(Spin rate, measurement, numeric)
+    - import: $field(Spin rate; measurement; numeric)
 
 - parameter: SPIN_AXIS
   where:
     name: Pitching*
   steps:
-    - import: $field(Spin axis, measurement, numeric)
+    - import: $field(Spin axis; measurement; numeric)
 
 
 #############

--- a/cricket-bowling.calqulus.yaml
+++ b/cricket-bowling.calqulus.yaml
@@ -481,13 +481,13 @@
   where:
     name: Bowling*
   steps:
-    - import: $field(Ball velocity in mps, measurement)
+    - import: $field(Ball velocity in mps; measurement)
 
 - parameter: HEIGHT
   where:
     name: Bowling*
   steps:
-    - import: $field(Height, measurement, numeric)
+    - import: $field(Height; measurement; numeric)
 
 ############
 ## METRICS ##

--- a/cycling.calqulus.yaml
+++ b/cycling.calqulus.yaml
@@ -167,7 +167,7 @@
   where:
     name: Cycling*
   steps:
-    - import: $field(Load, measurement, numeric)
+    - import: $field(Load; measurement; numeric)
 
 - parameter: head_tube_spacers_above
   where:


### PR DESCRIPTION
Preparing for the coming update where the syntax of the field accessor has changed from using commas to use semicolons instead.

This should be merged simultaneously with version 1.1 of Calqulus.

Work item:  [AB#32435](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/32435)