### PR TITLE
FA: Consistent naming for measurements

### DIFF
--- a/functional-assessment.calqulus.yaml
+++ b/functional-assessment.calqulus.yaml
@@ -8,7 +8,7 @@
 
 - template: templates/fa/cutting.calqulus.yaml
   where:
-    name: Cutting*
+    name: Cut*
 
 - template: templates/fa/cod.calqulus.yaml
   where:
@@ -44,7 +44,7 @@
 
 - template: templates/fa/squatting.calqulus.yaml
   where:
-    name: Squatting*
+    name: Squat*
 
 - template: templates/generic/generic.calqulus.yaml
   where:
@@ -52,7 +52,7 @@
 
 - template: templates/running/running.calqulus.yaml
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
 
 - template: templates/fa/balance.calqulus.yaml
   where:

--- a/functional-assessment.calqulus.yaml
+++ b/functional-assessment.calqulus.yaml
@@ -36,7 +36,7 @@
 
 - template: templates/fa/tapping.calqulus.yaml
   where:
-    name: Tapping*
+    name: Tap*
 
 - template: templates/fa/ll.calqulus.yaml
   where:

--- a/running.calqulus.yaml
+++ b/running.calqulus.yaml
@@ -8,7 +8,7 @@
 
 - parameter: Pelvis_Height_Normalised
   where:
-    name: Running*
+    name: Run*
   steps:
     - segment: Hips => hipsDynamic
     - segment: Hips?name=Static* => hipsStatic
@@ -22,7 +22,7 @@
 - parameter: Left Pelvic Angles
   set: left
   where:
-    name: Running*
+    name: Run*
     session: 
        FA session: "!true"
   steps:
@@ -33,7 +33,7 @@
 - parameter: Right Pelvic Angles
   set: right
   where:
-    name: Running*
+    name: Run*
     fields: 
        FA session: "!true"
   steps:
@@ -45,7 +45,7 @@
 - parameter: Left Elbow Angle
   set: left
   where:
-    name: Running*
+    name: Run*
   steps:
     - angle: [LeftArm, LeftForeArm, LeftHand]
     - convert: $prev
@@ -55,7 +55,7 @@
 - parameter: Right Elbow Angle
   set: right
   where:
-    name: Running*
+    name: Run*
   steps:
     - angle: [RightArm, RightForeArm, RightHand]
     - convert: $prev

--- a/templates/fa/cutting-events-kinematics.calqulus.yaml
+++ b/templates/fa/cutting-events-kinematics.calqulus.yaml
@@ -17,7 +17,7 @@
 # Left
 - event: TouchDown_kinematics
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: LFT_DistEndAcc.y
@@ -26,7 +26,7 @@
 
 - event: TouchDown_prio
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - if: exists(LON_force)
@@ -35,7 +35,7 @@
 
 - event: TouchDown_prio2
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - if: exists(UltimateTouchDown_L_ML)
@@ -44,7 +44,7 @@
 
 - event: TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - if: exists(TouchDown_prio)
@@ -53,7 +53,7 @@
 
 - event: TakeOff_kinematics
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - threshold: LFT_DistEndPos.z
@@ -65,7 +65,7 @@
 
 - event: TakeOff_prio
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - if: exists(LOFF_force)
@@ -74,7 +74,7 @@
 
 - event: TakeOff_prio2
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - if: exists(UltimateTakeOff_L_ML)
@@ -83,7 +83,7 @@
 
 - event: TakeOff
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - if: exists(TakeOff_prio)
@@ -92,7 +92,7 @@
 
 - event: temp_R1
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [RFT_DistEndVel.y, BOF, TouchDown]
@@ -102,7 +102,7 @@
 
 - event: Right Penultimate TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: right
   steps:
     - negate: RFT_DistEndVel.z
@@ -112,7 +112,7 @@
 
 - event: temp_R2
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [RFT_DistEndVel.z, BOF, TakeOff]
@@ -121,7 +121,7 @@
 
 - event: Right Penultimate TakeOff
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: right
   steps:
     - eventMask: [RFT_DistEndVel.z, temp_R1, temp_R2]
@@ -132,7 +132,7 @@
 
 - event: Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   steps:
     - eventMask: [Left Knee Angles.x, TouchDown, TakeOff]
     - max:
@@ -142,7 +142,7 @@
 # Right
 - event: TouchDown_kinematics
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: RFT_DistEndAcc.y
@@ -151,7 +151,7 @@
 
 - event: TouchDown_prio
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - if: exists(RON_force)
@@ -160,7 +160,7 @@
 
 - event: TouchDown_prio2
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - if: exists(UltimateTouchDown_R_ML)
@@ -169,7 +169,7 @@
 
 - event: TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - if: exists(TouchDown_prio)
@@ -178,7 +178,7 @@
 
 - event: TakeOff_kinematics
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - threshold: RFT_DistEndPos.z
@@ -189,7 +189,7 @@
 
 - event: TakeOff_prio
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - if: exists(ROFF_force)
@@ -198,7 +198,7 @@
 
 - event: TakeOff_prio2
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - if: exists(UltimateTakeOff_R_ML)
@@ -207,7 +207,7 @@
 
 - event: TakeOff
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - if: exists(TakeOff_prio)
@@ -216,7 +216,7 @@
 
 - event: temp_L1
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [LFT_DistEndVel.y, BOF, TouchDown]
@@ -226,7 +226,7 @@
 
 - event: Left Penultimate TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: left
   steps:
     - negate: LFT_DistEndVel.z
@@ -236,7 +236,7 @@
 
 - event: temp_L2
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [LFT_DistEndVel.z, BOF, TakeOff]
@@ -245,7 +245,7 @@
 
 - event: Left Penultimate TakeOff
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: left
   steps:
     - eventMask: [LFT_DistEndVel.z, temp_L1, temp_L2]
@@ -256,7 +256,7 @@
 
 - event: Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   steps:
     - eventMask: [Right Knee Angles.x, TouchDown, TakeOff]
     - max:
@@ -303,28 +303,28 @@
 # Unified event names for web
 - event: LeftPlotStart
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: TouchDown
 
 - event: LeftPlotEnd
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: TakeOff
 
 - event: RightPlotStart
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: TouchDown
 
 - event: RightPlotEnd
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: TakeOff

--- a/templates/fa/cutting.calqulus.yaml
+++ b/templates/fa/cutting.calqulus.yaml
@@ -41,28 +41,28 @@
 # Left -------------
 - parameter: Left_PelvisCGPos_vel_mag@TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: PelvisCGPos_vel_mag@TouchDown
 
 - parameter: Left_PelvisCGPos_vel_mag@TakeOff
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: PelvisCGPos_vel_mag@TakeOff
 
 - parameter: Left_ContactTime
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventDuration: [TouchDown, TakeOff]
 
 - parameter: Left_Completion_time
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventDuration: [Virtual_gate_start, Virtual_gate_end]
@@ -70,77 +70,77 @@
 # Joint angle at event
 - parameter: Left Knee Angles@TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Knee Angles@TouchDown
 
 - parameter: Left Hip Angles@TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Hip Angles@TouchDown
 
 - parameter: Left Thorax Angles@TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Thorax Angles@TouchDown
 
 - parameter: Left Knee Angles@TakeOff
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Knee Angles@TakeOff
 
 - parameter: Left Hip Angles@TakeOff
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Hip Angles@TakeOff
 
 - parameter: Left Thorax Angles@TakeOff
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Thorax Angles@TakeOff
 
 - parameter: Left Ankle Angles@Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Ankle Angles@Max_knee_flex
 
 - parameter: Left Knee Angles@Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Knee Angles@Max_knee_flex
 
 - parameter: Left Hip Angles@Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Hip Angles@Max_knee_flex
 
 - parameter: Left Thorax Angles@Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - import: Left Thorax Angles@Max_knee_flex
 
 - parameter: COM_displacement_Left_MEAN_range
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Hips, TouchDown, TakeOff]
@@ -155,7 +155,7 @@
 
 - parameter: Left Hip Angles_min
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Hip Angles, TouchDown, TakeOff]
@@ -163,7 +163,7 @@
 
 - parameter: Left Knee Angles_min
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Knee Angles, TouchDown, TakeOff]
@@ -171,7 +171,7 @@
 
 - parameter: Left Ankle Angles_min
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Ankle Angles, TouchDown, TakeOff]
@@ -179,7 +179,7 @@
 
 - parameter: Left Hip Angles_max
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Hip Angles, TouchDown, TakeOff]
@@ -187,7 +187,7 @@
 
 - parameter: Left Knee Angles_max
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Knee Angles, TouchDown, TakeOff]
@@ -195,7 +195,7 @@
 
 - parameter: Left Ankle Angles_max
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Ankle Angles, TouchDown, TakeOff]
@@ -204,7 +204,7 @@
 # penultimate
 - parameter: Right Hip Angles_max_penultimate
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: right
   steps:
     - eventMask: [Right Hip Angles, Right Penultimate TouchDown, Right Penultimate TakeOff]
@@ -212,7 +212,7 @@
 
 - parameter: Right Knee Angles_max_penultimate
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: right
   steps:
     - eventMask: [Right Knee Angles, Right Penultimate TouchDown, Right Penultimate TakeOff]
@@ -220,7 +220,7 @@
 
 - parameter: Right Ankle Angles_max_penultimate
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: right
   steps:
     - eventMask: [Right Ankle Angles, Right Penultimate TouchDown, Right Penultimate TakeOff]
@@ -228,7 +228,7 @@
 
 - parameter: Left Knee Angles_max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Knee Angles, TouchDown, Max_knee_flex]
@@ -236,7 +236,7 @@
 
 - parameter: Left Thorax Angles_max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
   set: left
   steps:
     - eventMask: [Left Thorax Angles, TouchDown, Max_knee_flex]
@@ -245,28 +245,28 @@
 # Right -----------
 - parameter: Right_PelvisCGPos_vel_mag@TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: PelvisCGPos_vel_mag@TouchDown
 
 - parameter: Right_PelvisCGPos_vel_mag@TakeOff
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: PelvisCGPos_vel_mag@TakeOff
 
 - parameter: Right_ContactTime
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventDuration: [TouchDown, TakeOff]
 
 - parameter: Right_Completion_time
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventDuration: [Virtual_gate_start, Virtual_gate_end]
@@ -274,77 +274,77 @@
 # Joint angle at event
 - parameter: Right Knee Angles@TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Knee Angles@TouchDown
 
 - parameter: Right Hip Angles@TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Hip Angles@TouchDown
 
 - parameter: Right Thorax Angles@TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Thorax Angles@TouchDown
 
 - parameter: Right Knee Angles@TakeOff
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Knee Angles@TakeOff
 
 - parameter: Right Hip Angles@TakeOff
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Hip Angles@TakeOff
 
 - parameter: Right Thorax Angles@TakeOff
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Thorax Angles@TakeOff
 
 - parameter: Right Ankle Angles@Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Ankle Angles@Max_knee_flex
 
 - parameter: Right Knee Angles@Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Knee Angles@Max_knee_flex
 
 - parameter: Right Hip Angles@Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Hip Angles@Max_knee_flex
 
 - parameter: Right Thorax Angles@Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - import: Right Thorax Angles@Max_knee_flex
 
 - parameter: COM_displacement_Right_MEAN_range
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Hips, TouchDown, TakeOff]
@@ -359,7 +359,7 @@
 
 - parameter: Right Hip Angles_min
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Hip Angles, TouchDown, TakeOff]
@@ -367,7 +367,7 @@
 
 - parameter: Right Knee Angles_min
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Knee Angles, TouchDown, TakeOff]
@@ -375,7 +375,7 @@
 
 - parameter: Right Ankle Angles_min
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Ankle Angles, TouchDown, TakeOff]
@@ -383,7 +383,7 @@
 
 - parameter: Right Hip Angles_max
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Hip Angles, TouchDown, TakeOff]
@@ -391,7 +391,7 @@
 
 - parameter: Right Knee Angles_max
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Knee Angles, TouchDown, TakeOff]
@@ -399,7 +399,7 @@
 
 - parameter: Right Ankle Angles_max
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Ankle Angles, TouchDown, TakeOff]
@@ -408,7 +408,7 @@
 # penultimate
 - parameter: Left Hip Angles_max_penultimate
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: left
   steps:
     - eventMask: [Left Hip Angles, Left Penultimate TouchDown, Left Penultimate TakeOff]
@@ -416,7 +416,7 @@
 
 - parameter: Left Knee Angles_max_penultimate
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: left
   steps:
     - eventMask: [Left Knee Angles, Left Penultimate TouchDown, Left Penultimate TakeOff]
@@ -424,7 +424,7 @@
 
 - parameter: Left Ankle Angles_max_penultimate
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: left
   steps:
     - eventMask: [Left Ankle Angles, Left Penultimate TouchDown, Left Penultimate TakeOff]
@@ -432,7 +432,7 @@
 
 - parameter: Right Knee Angles_max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Knee Angles, TouchDown, Max_knee_flex]
@@ -440,7 +440,7 @@
 
 - parameter: Right Thorax Angles_max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
   set: right
   steps:
     - eventMask: [Right Thorax Angles, TouchDown, Max_knee_flex]
@@ -450,7 +450,7 @@
 # Left
 - parameter: Left GRF_min
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -459,7 +459,7 @@
 
 - parameter: Left Hip Moment@TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -467,7 +467,7 @@
 
 - parameter: Left Knee Moment@TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -475,7 +475,7 @@
 
 - parameter: Left Ankle Moment@TouchDown
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -483,7 +483,7 @@
 
 - parameter: Left Hip Moment@Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -491,7 +491,7 @@
 
 - parameter: Left Knee Moment@Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -499,7 +499,7 @@
 
 - parameter: Left Ankle Moment@Max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -507,7 +507,7 @@
 
 - parameter: Left Hip Moment_max_concentric
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -516,7 +516,7 @@
 
 - parameter: Left Knee Moment_max_concentric
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -525,7 +525,7 @@
 
 - parameter: Left Ankle Moment_max_concentric
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -534,7 +534,7 @@
 
 - parameter: Left Hip Moment_mean
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -543,7 +543,7 @@
 
 - parameter: Left Knee Moment_mean
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -552,7 +552,7 @@
 
 - parameter: Left Hip Moment_max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -561,7 +561,7 @@
 
 - parameter: Left Knee Moment_max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -570,7 +570,7 @@
 
 - parameter: Left Ankle Moment_max_knee_flex
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -579,7 +579,7 @@
 
 - parameter: Left Knee Moment_max
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -588,7 +588,7 @@
 
 - parameter: Left GRF_max
   where:
-    name: Cutting_L*
+    name: (Cut|Cutting)_L*
     force: left
   set: left
   steps:
@@ -598,7 +598,7 @@
 # Right
 - parameter: Right GRF_min
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -607,7 +607,7 @@
 
 - parameter: Right Hip Moment@TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -615,7 +615,7 @@
 
 - parameter: Right Knee Moment@TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -623,7 +623,7 @@
 
 - parameter: Right Ankle Moment@TouchDown
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -631,7 +631,7 @@
 
 - parameter: Right Hip Moment@Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -639,7 +639,7 @@
 
 - parameter: Right Knee Moment@Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -647,7 +647,7 @@
 
 - parameter: Right Ankle Moment@Max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -655,7 +655,7 @@
 
 - parameter: Right Hip Moment_max_concentric
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -664,7 +664,7 @@
 
 - parameter: Right Knee Moment_max_concentric
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -673,7 +673,7 @@
 
 - parameter: Right Ankle Moment_max_concentric
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -682,7 +682,7 @@
 
 - parameter: Right Hip Moment_mean
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -691,7 +691,7 @@
 
 - parameter: Right Knee Moment_mean
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -700,7 +700,7 @@
 
 - parameter: Right Hip Moment_max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -709,7 +709,7 @@
 
 - parameter: Right Knee Moment_max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -718,7 +718,7 @@
 
 - parameter: Right Ankle Moment_max_knee_flex
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -727,7 +727,7 @@
 
 - parameter: Right Knee Moment_max
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:
@@ -736,7 +736,7 @@
 
 - parameter: Right GRF_max
   where:
-    name: Cutting_R*
+    name: (Cut|Cutting)_R*
     force: right
   set: right
   steps:

--- a/templates/fa/squatting.calqulus.yaml
+++ b/templates/fa/squatting.calqulus.yaml
@@ -223,7 +223,7 @@
     - count: EccentricEnd_ML_temp
 
 # Squatting depth
-- parameter: Squat_depth_Squat_B
+- parameter: Squatting_depth_Squat_B
   where:
     name: (Squat|Squatting)_B*
   steps:
@@ -239,7 +239,7 @@
     - import: PelvisCGPos@Pelvis_lowest_refined
     - subtract: [$prev(2), $prev]
 
-- parameter: Squat_depth_Squat_L
+- parameter: Squatting_depth_Squat_L
   where:
     name: (Squat|Squatting)_L*
   steps:
@@ -255,7 +255,7 @@
     - import: PelvisCGPos@Pelvis_lowest_refined
     - subtract: [$prev(2), $prev]
 
-- parameter: Squat_depth_Squat_R
+- parameter: Squatting_depth_Squat_R
   where:
     name: (Squat|Squatting)_R*
   steps:

--- a/templates/fa/squatting.calqulus.yaml
+++ b/templates/fa/squatting.calqulus.yaml
@@ -135,13 +135,13 @@
 
 - event: TOP_L_calqulus
   where:
-    name: (Squatting_L|Squatting_B)*
+    name: ((Squat|Squatting)_(L|B))*
   steps:
     - import: TOP_calqulus
 
 - event: TOP_R_calqulus
   where:
-    name: (Squatting_R|Squatting_B)*
+    name: ((Squat|Squatting)_(R|B))*
   steps:
     - import: TOP_calqulus
 
@@ -154,7 +154,7 @@
 
 - event: TOP_L
   where:
-    name: (Squatting_L|Squatting_B)*
+    name: ((Squat|Squatting)_(L|B))*
   steps:
   - if: exists(EccentricStart_ML) && Pelvis_lowest_count == ML_cycles_count && ML_cycles_count > 1
     then: EccentricStart_ML
@@ -162,7 +162,7 @@
 
 - event: TOP_R
   where:
-    name: (Squatting_R|Squatting_B)*
+    name: ((Squat|Squatting)_(R|B))*
   steps:
   - if: exists(EccentricStart_ML) && Pelvis_lowest_count == ML_cycles_count && ML_cycles_count > 1
     then: EccentricStart_ML
@@ -171,28 +171,28 @@
 # Unified event names for web
 - event: LeftPlotStart
   where:
-    name: (Squatting_L|Squatting_B)*
+    name: ((Squat|Squatting)_(L|B))*
   set: left
   steps:
     - import: TOP_L
 
 - event: LeftPlotEnd
   where:
-    name: (Squatting_L|Squatting_B)*
+    name: ((Squat|Squatting)_(L|B))*
   set: left
   steps:
     - import: TOP_L
 
 - event: RightPlotStart
   where:
-    name: (Squatting_R|Squatting_B)*
+    name: ((Squat|Squatting)_(R|B))*
   set: right
   steps:
     - import: TOP_R
 
 - event: RightPlotEnd
   where:
-    name: (Squatting_R|Squatting_B)*
+    name: ((Squat|Squatting)_(R|B))*
   set: right
   steps:
     - import: TOP_R
@@ -223,9 +223,9 @@
     - count: EccentricEnd_ML_temp
 
 # Squatting depth
-- parameter: Squatting_depth_Squat_B
+- parameter: Squat_depth_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
   steps:
     - refineEvent: TOP
       sequence: [TOP, Pelvis_lowest]
@@ -239,9 +239,9 @@
     - import: PelvisCGPos@Pelvis_lowest_refined
     - subtract: [$prev(2), $prev]
 
-- parameter: Squatting_depth_Squat_L
+- parameter: Squat_depth_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
   steps:
     - refineEvent: TOP
       sequence: [TOP, Pelvis_lowest]
@@ -255,9 +255,9 @@
     - import: PelvisCGPos@Pelvis_lowest_refined
     - subtract: [$prev(2), $prev]
 
-- parameter: Squatting_depth_Squat_R
+- parameter: Squat_depth_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
   steps:
     - refineEvent: TOP
       sequence: [TOP, Pelvis_lowest]
@@ -275,42 +275,42 @@
 
 - parameter: Left Hip Angles_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
   steps:
     - eventMask: [Left Hip Angles, TOP, TOP]
     - max:
 
 - parameter: Left Knee Angles_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
   steps:
     - eventMask: [Left Knee Angles, TOP, TOP]
     - max:
 
 - parameter: Left Ankle Angles_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
   steps:
     - eventMask: [Left Ankle Angles, TOP, TOP]
     - max:
 
 - parameter: Right Hip Angles_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
   steps:
     - eventMask: [Right Hip Angles, TOP, TOP]
     - max:
 
 - parameter: Right Knee Angles_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
   steps:
     - eventMask: [Right Knee Angles, TOP, TOP]
     - max:
 
 - parameter: Right Ankle Angles_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
   steps:
     - eventMask: [Right Ankle Angles, TOP, TOP]
     - max:
@@ -318,21 +318,21 @@
 # Left ---
 - parameter: Left Hip Angles_max_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
   steps:
     - eventMask: [Left Hip Angles, TOP, TOP]
     - max:
 
 - parameter: Left Knee Angles_max_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
   steps:
     - eventMask: [Left Knee Angles, TOP, TOP]
     - max:
 
 - parameter: Left Ankle Angles_max_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
   steps:
     - eventMask: [Left Ankle Angles, TOP, TOP]
     - max:
@@ -340,21 +340,21 @@
 # Right ---
 - parameter: Right Hip Angles_max_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
   steps:
     - eventMask: [Right Hip Angles, TOP, TOP]
     - max:
 
 - parameter: Right Knee Angles_max_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
   steps:
     - eventMask: [Right Knee Angles, TOP, TOP]
     - max:
 
 - parameter: Right Ankle Angles_max_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
   steps:
     - eventMask: [Right Ankle Angles, TOP, TOP]
     - max:
@@ -363,14 +363,14 @@
 # Bilateral - Total
 - parameter: Total GRF
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - add: [Left GRF, Right GRF]
 
 - parameter: Total GRF_max_concentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Total GRF, Pelvis_lowest, TOP]
@@ -378,7 +378,7 @@
 
 - parameter: Total GRF_mean_concentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Total GRF, Pelvis_lowest, TOP]
@@ -386,7 +386,7 @@
 
 - parameter: Total GRF_max_eccentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Total GRF, TOP, Pelvis_lowest]
@@ -394,7 +394,7 @@
 
 - parameter: Total GRF_mean_eccentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Total GRF, TOP, Pelvis_lowest]
@@ -403,7 +403,7 @@
 # Bilateral - Left
 - parameter: Left GRF_max_concentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Left GRF, Pelvis_lowest, TOP]
@@ -411,7 +411,7 @@
 
 - parameter: Left GRF_mean_concentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Left GRF, Pelvis_lowest, TOP]
@@ -419,7 +419,7 @@
 
 - parameter: Left GRF_max_eccentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Left GRF, TOP, Pelvis_lowest]
@@ -427,7 +427,7 @@
 
 - parameter: Left GRF_mean_eccentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Left GRF, TOP, Pelvis_lowest]
@@ -435,7 +435,7 @@
 
 - parameter: Left GRF_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Left GRF, TOP, TOP]
@@ -444,7 +444,7 @@
 # Bilateral - Right
 - parameter: Right GRF_max_concentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Right GRF, Pelvis_lowest, TOP]
@@ -452,7 +452,7 @@
 
 - parameter: Right GRF_mean_concentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Right GRF, Pelvis_lowest, TOP]
@@ -460,7 +460,7 @@
 
 - parameter: Right GRF_max_eccentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Right GRF, TOP, Pelvis_lowest]
@@ -468,7 +468,7 @@
 
 - parameter: Right GRF_mean_eccentric_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Right GRF, TOP, Pelvis_lowest]
@@ -476,7 +476,7 @@
 
 - parameter: Right GRF_max_Squat_B
   where:
-    name: Squatting_B*
+    name: (Squat|Squatting)_B*
     force: both
   steps:
     - eventMask: [Right GRF, TOP, TOP]
@@ -485,7 +485,7 @@
 # Single leg - Left
 - parameter: Left GRF_max_concentric_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
     force: left
   steps:
     - eventMask: [Left GRF, Pelvis_lowest, TOP]
@@ -493,7 +493,7 @@
 
 - parameter: Left GRF_mean_concentric_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
     force: left
   steps:
     - eventMask: [Left GRF, Pelvis_lowest, TOP]
@@ -501,7 +501,7 @@
 
 - parameter: Left GRF_max_eccentric_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
     force: left
   steps:
     - eventMask: [Left GRF, TOP, Pelvis_lowest]
@@ -509,7 +509,7 @@
 
 - parameter: Left GRF_mean_eccentric_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
     force: left
   steps:
     - eventMask: [Left GRF, TOP, Pelvis_lowest]
@@ -517,7 +517,7 @@
 
 - parameter: Left GRF_max_Squat_L
   where:
-    name: Squatting_L*
+    name: (Squat|Squatting)_L*
     force: left
   steps:
     - eventMask: [Left GRF, TOP, TOP]
@@ -526,7 +526,7 @@
 # Single leg - Right
 - parameter: Right GRF_max_concentric_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
     force: right
   steps:
     - eventMask: [Right GRF, Pelvis_lowest, TOP]
@@ -534,7 +534,7 @@
 
 - parameter: Right GRF_mean_concentric_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
     force: right
   steps:
     - eventMask: [Right GRF, Pelvis_lowest, TOP]
@@ -542,7 +542,7 @@
 
 - parameter: Right GRF_max_eccentric_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
     force: right
   steps:
     - eventMask: [Right GRF, TOP, Pelvis_lowest]
@@ -550,7 +550,7 @@
 
 - parameter: Right GRF_mean_eccentric_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
     force: right
   steps:
     - eventMask: [Right GRF, TOP, Pelvis_lowest]
@@ -558,7 +558,7 @@
 
 - parameter: Right GRF_max_Squat_R
   where:
-    name: Squatting_R*
+    name: (Squat|Squatting)_R*
     force: right
   steps:
     - eventMask: [Right GRF, TOP, TOP]

--- a/templates/running/running-events-kinematics.calqulus.yaml
+++ b/templates/running/running-events-kinematics.calqulus.yaml
@@ -9,7 +9,7 @@
 - event: LTOE_RISE
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - threshold: Left_MID_FOOT_acc.z => sig
       value: 0
@@ -20,7 +20,7 @@
 # - event: LTO_treadmill_old
 #   set: left
 #   where:
-#     name: ^(Running|Gait)*
+#     name: ^(Gait|Run|Walk)*
 #   steps:
 #     - peakFinder: Left_MID_FOOT_acc.z => sig2
 #     - eventMask: [sig2, LTOE_RISE, LTOE_RISE]
@@ -29,7 +29,7 @@
 - event: LTO_treadmill
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: LHeelBack_vel.z => sig
     - eventMask: [sig, L_MID_STANCE, L_MID_STANCE]
@@ -39,7 +39,7 @@
 - event: RTOE_RISE
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - threshold: Right_MID_FOOT_acc.z => sig
       value: 0
@@ -50,7 +50,7 @@
 # - event: RTO_treadmill
 #   set: right
 #   where:
-#     name: ^(Running|Gait)*
+#     name: ^(Gait|Run|Walk)*
 #   steps:
 #     - peakFinder: Right_MID_FOOT_acc.z => sig
 #     - eventMask: [sig, RTOE_RISE, RTOE_RISE]
@@ -59,7 +59,7 @@
 - event: RTO_treadmill
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: RHeelBack_vel.z => sig
     - eventMask: [sig, L_MID_STANCE, L_MID_STANCE]
@@ -70,7 +70,7 @@
 - event: L_PEAK_MID_FOOT_VEL_z
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left_MID_FOOT_vel.z => sig
       width: 10
@@ -81,7 +81,7 @@
 - event: L_MID_FOOT_vel_negative
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - threshold: Left_MID_FOOT_vel.z => sig
       value: 0
@@ -92,7 +92,7 @@
 - event: temp_event_1
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - threshold: Left_MID_FOOT_vel.y
       value: 0
@@ -101,7 +101,7 @@
 - event: temp_event_2
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left_MID_FOOT_vel.y => sig
     - eventMask: [sig, L_PEAK_MID_FOOT_VEL_z, temp_event_1]
@@ -110,7 +110,7 @@
 - event: LFS_treadmill
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     # - peakFinder: Left_MID_FOOT_vel.z => sig
     #   width: 10
@@ -145,7 +145,7 @@
 - event: RFS_treadmill
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Right_MID_FOOT_vel.z => sig
       width: 10
@@ -180,7 +180,7 @@
 - event: L_MID_STANCE
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [Left_MID_FOOT, Pelvis_CGPos]
     - threshold: $prev.y
@@ -190,7 +190,7 @@
 - event: R_MID_STANCE
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [Right_MID_FOOT, Pelvis_CGPos]
     - threshold: $prev.y
@@ -203,7 +203,7 @@
 - event: LFS_overground
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: [LForefoot2_wrt_Pelvis.y]
       height: 0
@@ -222,7 +222,7 @@
 - event: RFS_overground
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: [RForefoot2_wrt_Pelvis.y]
       height: 0
@@ -242,7 +242,7 @@
 - event: LTO_overground
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - divide: [$framerate, 40]
       output: shift
@@ -283,7 +283,7 @@
 - event: RTO_overground
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - divide: [$framerate, 40]
       output: shift
@@ -326,7 +326,7 @@
 - event: LFS_kinematics
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: LFS_overground
@@ -335,7 +335,7 @@
 - event: LTO_kinematics
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: LTO_overground
@@ -344,7 +344,7 @@
 - event: RFS_kinematics
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: RFS_overground
@@ -353,7 +353,7 @@
 - event: RTO_kinematics
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: RTO_overground
@@ -371,7 +371,7 @@
 - event: LFS_kinetics
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: left
   steps:
     # Specify kinetics window in which evens are located
@@ -401,7 +401,7 @@
 - event: LTO_kinetics
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: left
   steps:
     - subtract: [LOFF_force, force_window]
@@ -427,7 +427,7 @@
 - event: RFS_kinetics
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: right
   steps:
     - add: [RON_force, force_window]
@@ -453,7 +453,7 @@
 - event: RTO_kinetics
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: right
   steps:
     - subtract: [ROFF_force, force_window]
@@ -479,7 +479,7 @@
 - event: LFS
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: exists(LFS_kinetics)
       then: LFS_kinetics
@@ -488,7 +488,7 @@
 - event: LTO
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: exists(LTO_kinetics)
       then: LTO_kinetics
@@ -497,7 +497,7 @@
 - event: RFS
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: exists(RFS_kinetics)
       then: RFS_kinetics
@@ -506,7 +506,7 @@
 - event: RTO
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: exists(RTO_kinetics)
       then: RTO_kinetics
@@ -519,7 +519,7 @@
 - parameter: Left_ZENI
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -564,7 +564,7 @@
 - event: LFS_ZENI
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left_ZENI_heel_diff
       width: 3
@@ -574,7 +574,7 @@
 - event: LTO_temp
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left_ZENI_toe_diff_inv
       width: 3
@@ -584,7 +584,7 @@
 - event: LTO_ZENI
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - refineEvent: LTO_temp
       sequence: [LFS, LTO_temp]
@@ -592,7 +592,7 @@
 - event: L_MID_STANCE_ZENI
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left_ZENI_toe_diff_abs_inv => sign_change
       width: 10
@@ -603,7 +603,7 @@
 - parameter: Right_ZENI
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot => r_foot
       space: VirtualLab
@@ -648,7 +648,7 @@
 - event: RFS_ZENI
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Right_ZENI_heel_diff
       width: 3
@@ -658,7 +658,7 @@
 - event: RTO_temp
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Right_ZENI_toe_diff_inv
       width: 3
@@ -668,7 +668,7 @@
 - event: RTO_ZENI
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - refineEvent: RTO_temp
       sequence: [RFS, RTO_temp]
@@ -676,7 +676,7 @@
 - event: R_MID_STANCE_ZENI
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Right_ZENI_toe_diff_abs_inv => sign_change
       width: 10
@@ -688,7 +688,7 @@
 - event: L_peak_knee_flex
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left Knee Angles.x => knee_flex_max
       width: 10
@@ -697,7 +697,7 @@
 - event: R_peak_knee_flex
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Right Knee Angles.x => knee_flex_max
       width: 10
@@ -706,7 +706,7 @@
 - event: L_stride_angle_max
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left Stride Angle.x => stride_angle_max
       width: 10
@@ -716,7 +716,7 @@
 - event: R_stride_angle_max
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Right Stride Angle.x => stride_angle_max
       width: 10
@@ -726,7 +726,7 @@
 - event: L_peak_hip_flex
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Left Hip Angles.x => hip_flex_max
       width: 10
@@ -736,7 +736,7 @@
 - event: R_peak_hip_flex
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - peakFinder: Right Hip Angles.x => hip_flex_max
       width: 10
@@ -746,7 +746,7 @@
 - event: L_Ankle_cross
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - threshold: [L_ankle_crossing_pelvis]
       value: 0
@@ -755,7 +755,7 @@
 - event: R_Ankle_cross
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - threshold: [R_ankle_crossing_pelvis]
       value: 0
@@ -764,7 +764,7 @@
 - event: L_peak_hip_extension_stride
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - negate: Left Hip Angles.x => hip_neg
     - peakFinder: [hip_neg, LFS, LFS]
@@ -774,7 +774,7 @@
 - event: R_peak_hip_extension_stride
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - negate: Right Hip Angles.x => hip_neg
     - peakFinder: [hip_neg, RFS, RFS]
@@ -784,7 +784,7 @@
 - event: L_peak_knee_extension_stride
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - negate: Left Knee Angles.x => knee_neg
     - peakFinder: [knee_neg, LFS, LFS]
@@ -797,7 +797,7 @@
 - event: R_peak_knee_extension_stride
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - negate: Right Knee Angles.x => knee_neg
     - peakFinder: [knee_neg, RFS, RFS]
@@ -811,14 +811,14 @@
 - event: LeftPlotStart
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: LFS
 
 - event: LeftPlotEnd
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     # - import: LTO
     - import: LFS
@@ -826,14 +826,14 @@
 - event: RightPlotStart
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: RFS
 
 - event: RightPlotEnd
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     # - import: RTO
     - import: RFS
@@ -841,7 +841,7 @@
 - event: LeftPlotStartForce
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: left
   steps:
     - import: LON_force
@@ -849,7 +849,7 @@
 - event: LeftPlotEndForce
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: left
   steps:
     - import: LOFF_force
@@ -857,7 +857,7 @@
 - event: RightPlotStartForce
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: right
   steps:
     - import: RON_force
@@ -865,7 +865,7 @@
 - event: RightPlotEndForce
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: right
   steps:
     - import: ROFF_force
@@ -874,7 +874,7 @@
 - event: LON
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: left
   steps:
     - import: LON_force
@@ -882,7 +882,7 @@
 - event: RON
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
     force: right
   steps:
     - import: RON_force

--- a/templates/running/running.calqulus.yaml
+++ b/templates/running/running.calqulus.yaml
@@ -46,7 +46,7 @@
 - parameter: Left_MID_FOOT_vel
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot
       space: VirtualLab
@@ -65,7 +65,7 @@
 - parameter: Left_MID_FOOT_acc
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot
       space: VirtualLab
@@ -83,7 +83,7 @@
 - parameter: LHeelBack_vel
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - marker: LHeelBack => sig
     - velocity:
@@ -91,7 +91,7 @@
 - parameter: Right_MID_FOOT_vel
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot
       space: VirtualLab
@@ -110,7 +110,7 @@
 - parameter: Right_MID_FOOT_acc
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot
       space: VirtualLab
@@ -128,7 +128,7 @@
 - parameter: RHeelBack_vel
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - marker: RHeelBack => sig
     - velocity:
@@ -136,7 +136,7 @@
 # Midstance event is based on pelvis position wrt foot position
 - parameter: Pelvis_CGPos
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: Hips
       space: VirtualLab
@@ -148,7 +148,7 @@
 - parameter: LForefoot2_wrt_Pelvis
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - marker: LForefoot2 => foot
       space: VirtualLab
@@ -159,7 +159,7 @@
 - parameter: LHeelBack_wrt_Pelvis
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - marker: LHeelBack => heel
       space: VirtualLab
@@ -170,7 +170,7 @@
 - parameter: RForefoot2_wrt_Pelvis
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - marker: RForefoot2 => foot
       space: VirtualLab
@@ -181,7 +181,7 @@
 - parameter: RHeelBack_wrt_Pelvis
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - marker: RHeelBack => heel
       space: VirtualLab
@@ -191,7 +191,7 @@
 
 - parameter: Pelvis_COG_range
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Hips
       space: VirtualLab
@@ -206,14 +206,14 @@
 - parameter: Left Knee Angles_Velocity
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - velocity: Left Knee Angles => kneeAngleVel
 
 - parameter: Right Knee Angles_Velocity
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - velocity: Right Knee Angles => kneeAngleVel
 
@@ -222,7 +222,7 @@
 - parameter: Left_KNEE_Lin_Velocity
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftLeg
     - velocity: $prev
@@ -234,7 +234,7 @@
 - parameter: Right_KNEE_Lin_Velocity
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightLeg
     - velocity: $prev
@@ -248,7 +248,7 @@
 - parameter: L_KNEE_X
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftLeg => shank
       space: VirtualLab
@@ -264,7 +264,7 @@
 - parameter: R_KNEE_X
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightLeg
     - segment: Hips
@@ -281,7 +281,7 @@
 - parameter: LEFT_KNEE
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftLeg => shank
       space: VirtualLab
@@ -292,7 +292,7 @@
 - parameter: RIGHT_KNEE
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightLeg => shank
       space: VirtualLab
@@ -305,7 +305,7 @@
 - parameter: Left Tibial Rotation
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: [LeftFoot, LeftLeg]
     - multiply: [$prev, [1, 1, -1]]
@@ -313,7 +313,7 @@
 - parameter: Right Tibial Rotation
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: [RightFoot, RightLeg]
       output: tibialRot
@@ -323,14 +323,14 @@
 - parameter: Left Tibial Rotation_Velocity
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - velocity: Left Tibial Rotation => tibialRotVel
 
 - parameter: Right Tibial Rotation_Velocity
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - velocity: Right Tibial Rotation => tibialRotVel
 
@@ -339,14 +339,14 @@
 - parameter: Left Ankle Angles_Velocity
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - velocity: Left Ankle Angles => ankleAngleVel
 
 - parameter: Right Ankle Angles_Velocity
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - velocity: Right Ankle Angles => ankleAngleVel
 
@@ -355,7 +355,7 @@
 - parameter: Left Foot Contact Angle_shifted
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: LeftFoot => footContactAngle
       space: VirtualLab
@@ -364,7 +364,7 @@
 - parameter: Right Foot Contact Angle_shifted
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: RightFoot => footContactAngle
       space: VirtualLab
@@ -375,7 +375,7 @@
 - parameter: L_ANKLE_Y
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => foot
       space: VirtualLab
@@ -397,7 +397,7 @@
 - parameter: R_ANKLE_Y
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [Hips, RightFoot]
       space: VirtualLab
@@ -418,7 +418,7 @@
 - parameter: LEFT_ANKLE
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => ankle
       space: VirtualLab
@@ -429,7 +429,7 @@
 - parameter: RIGHT_ANKLE
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot => ankle
       space: VirtualLab
@@ -442,7 +442,7 @@
 - parameter: Left_ANKLE_Lin_Velocity
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot
       space: VirtualLab
@@ -454,7 +454,7 @@
 - parameter: Right_ANKLE_Lin_Velocity
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot
       space: VirtualLab
@@ -467,7 +467,7 @@
 
 - parameter: Trunk Angles_wrt_LAB
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: Spine2
       space: VirtualLab
@@ -475,7 +475,7 @@
 
 - parameter: Shoulder_Pelvis Angle
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: [Hips, Spine2]
 
@@ -484,7 +484,7 @@
 - parameter: L_ELBOW_RT_PELVIS_Y
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [LeftForeArm, Hips]
       space: VirtualLab
@@ -507,7 +507,7 @@
 - parameter: R_ELBOW_RT_PELVIS_Y
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [RightForeArm, Hips]
       space: VirtualLab
@@ -532,7 +532,7 @@
 - parameter: L_WRIST_RT_PELVIS_Y
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [LeftHand, Hips]
       space: VirtualLab
@@ -555,7 +555,7 @@
 - parameter: R_WRIST_RT_PELVIS_Y
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [RightHand, Hips]
       space: VirtualLab
@@ -578,7 +578,7 @@
 # --- 
 - parameter: L_ankle_crossing_pelvis
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: Hips => pelvis
       space: VirtualLab
@@ -590,7 +590,7 @@
 
 - parameter: R_ankle_crossing_pelvis
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: Hips => pelvis
     - convert: pelvis
@@ -607,7 +607,7 @@
 # Treadmill speed (calculated from left foot and right foot at midstance)
 - parameter: left_treadmill_speed
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -618,7 +618,7 @@
     
 - parameter: right_treadmill_speed
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot => r_foot
       space: VirtualLab
@@ -629,7 +629,7 @@
 
 - parameter: treadmill_speed
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - concatenate: [left_treadmill_speed, right_treadmill_speed]
     - mean: $prev
@@ -639,7 +639,7 @@
 
 - parameter: actual_running_speed_ms
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - velocity: Hips => pelvis_vel
       space: VirtualLab
@@ -654,7 +654,7 @@
 # Seconds per meter, to be displayed as minutes per kilometer.
 - parameter: seconds_per_meter
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - divide: [1, actual_running_speed_ms]
 
@@ -662,14 +662,14 @@
 # calculated as average speed divided by the subject height 
 - parameter: Statures_Per_Second
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - divide: [actual_running_speed_ms, "$field(Height; measurement; numeric)"]
 
 # Stride angle
 - parameter: Left Stride Angle@max
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftUpLeg => l_thigh
     - segment: RightUpLeg => r_thigh
@@ -681,7 +681,7 @@
      
 - parameter: Right Stride Angle@max
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftUpLeg => l_thigh
     - segment: RightUpLeg => r_thigh
@@ -695,7 +695,7 @@
 # 60 / ((left mean step time + right mean step time) / 2)
 - parameter: Steps_Per_Minute_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
   - eventDuration: [RFS, LFS]
     output: Left_Step_Time
@@ -717,7 +717,7 @@
 # Step length
 - parameter: Right_Step_Length_Mean_treadmill
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -735,7 +735,7 @@
 
 - parameter: Right_Step_Length_Mean_overground
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -749,7 +749,7 @@
 
 - parameter: Left_Step_Length_Mean_treadmill
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -767,7 +767,7 @@
 
 - parameter: Left_Step_Length_Mean_overground
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -781,7 +781,7 @@
 
 - parameter: Right_Step_Length_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: Right_Step_Length_Mean_overground
@@ -790,7 +790,7 @@
 
 - parameter: Left_Step_Length_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: Left_Step_Length_Mean_overground
@@ -799,7 +799,7 @@
 
 - parameter: Step_Length_Mean_MEAN
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - concatenate: [Right_Step_Length_Mean, Left_Step_Length_Mean]
     - mean: $prev
@@ -807,7 +807,7 @@
 # Stride length
 - parameter: Right_Stride_Length_Mean_treadmill
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot => foot
       space: VirtualLab
@@ -824,7 +824,7 @@
 
 - parameter: Right_Stride_Length_Mean_overground
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot => foot
       space: VirtualLab
@@ -837,7 +837,7 @@
 
 - parameter: Left_Stride_Length_Mean_treadmill
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => foot
       space: VirtualLab
@@ -854,7 +854,7 @@
 
 - parameter: Left_Stride_Length_Mean_overground
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => foot
       space: VirtualLab
@@ -867,7 +867,7 @@
 
 - parameter: Right_Stride_Length_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: Right_Stride_Length_Mean_overground
@@ -876,7 +876,7 @@
 
 - parameter: Left_Stride_Length_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - if: Pelvis_COG_range > 1
       then: Left_Stride_Length_Mean_overground
@@ -885,7 +885,7 @@
 
 - parameter: Stride_Length_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - concatenate: [Right_Stride_Length_Mean, Left_Stride_Length_Mean]
     - mean: $prev
@@ -895,7 +895,7 @@
 # note V3D script is calculating it using stride vector
 - parameter: Right_Stride_Width_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -907,7 +907,7 @@
 
 - parameter: Left_Stride_Width_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -919,7 +919,7 @@
 
 - parameter: Stride_Width_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - concatenate: [Right_Stride_Width_Mean, Left_Stride_Width_Mean]
     - mean: $prev
@@ -931,7 +931,7 @@
 # Cycle time # for FA Running
 - parameter: Cycle_Time
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - divide: [Left_Stride_Length_Mean, left_stride_time]
       output: left
@@ -943,40 +943,40 @@
 # Stance time # for FA Running
 - parameter: Left_Stance_Time
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [LFS, LTO]
     
 - parameter: Right_Stance_Time
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [RFS, RTO]
 
 # Swing time # for FA Running
 - parameter: Left_Swing_Time
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [LTO, LFS]
 
 - parameter: Right_Swing_Time
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [RTO, RFS]
 
 # Strides per minute
 - parameter: Left_Strides_Per_Minute_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - divide: [60, left_stride_time]
     - mean: $prev
 
 - parameter: Right_Strides_Per_Minute_Mean
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - divide: [60, right_stride_time]
     - mean: $prev
@@ -984,7 +984,7 @@
 # Vertical pelvis movement
 - parameter: Pelvis_Height_RANGE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Hips, LFS, RFS]
       output: mask
@@ -998,7 +998,7 @@
 # Contact time
 - parameter: Stance_Time_Mean_MEAN
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
   - eventDuration: [LFS, LTO]
     export: Left_Stance_Time_Mean
@@ -1012,7 +1012,7 @@
 # Flight time
 - parameter: Flight_Time_Mean_MEAN
   where:
-    name: Running*
+    name: Run*
   steps:
   - eventDuration: [LTO, RFS]
     export: Flight_time_LTO_RFS
@@ -1026,19 +1026,19 @@
 # Flight time/contact time ratio
 - parameter: Swing_Contact_Ratio
   where:
-    name: Running*
+    name: Run*
   steps:
   - divide: [Flight_Time_Mean_MEAN, Stance_Time_Mean_MEAN]
 
 - parameter: Left_Swing_Contact_Ratio
   where:
-    name: Running*
+    name: Run*
   steps:
   - divide: [Flight_time_LTO_RFS, Left_Stance_Time_Mean]
 
 - parameter: Right_Swing_Contact_Ratio
   where:
-    name: Running*
+    name: Run*
   steps:
   - divide: [Flight_time_RTO_LFS, Right_Stance_Time_Mean]
 
@@ -1046,7 +1046,7 @@
 - parameter: Left_HEEL_PELVIS_MEAN_X
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => l_foot
       space: VirtualLab
@@ -1064,7 +1064,7 @@
 - parameter: Right_HEEL_PELVIS_MEAN_X
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot => r_foot
       space: VirtualLab
@@ -1082,7 +1082,7 @@
 # Number of steps
 - parameter: Cycle_Time_Count
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
   - eventDuration: [LFS, RFS]
   - count: $prev => l_to_r_count
@@ -1095,21 +1095,21 @@
 - parameter: Left Pelvic Angles@LFS
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Pelvic Angles@LFS
 
 - parameter: Right Pelvic Angles@RFS
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Pelvic Angles@RFS
 
 # max during stance
 - parameter: Left Pelvic Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Pelvic Angles, LFS, LTO]
       truncate: true
@@ -1117,7 +1117,7 @@
 
 - parameter: Right Pelvic Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Pelvic Angles, RFS, RTO]
       truncate: true
@@ -1126,7 +1126,7 @@
 # min during stance
 - parameter: Left Pelvic Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Pelvic Angles, LFS, LTO]
       truncate: true
@@ -1134,7 +1134,7 @@
 
 - parameter: Right Pelvic Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Pelvic Angles, RFS, RTO]
       truncate: true
@@ -1143,7 +1143,7 @@
 # max during stride
 - parameter: Left Pelvic Angles_MAX_stride
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Pelvic Angles, LFS, LFS]
       truncate: true
@@ -1151,7 +1151,7 @@
 
 - parameter: Right Pelvic Angles_MAX_stride
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Pelvic Angles, RFS, RFS]
       truncate: true
@@ -1162,21 +1162,21 @@
 - parameter: L_HIP_ANGLE@LFS
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Hip Angles@LFS
 
 - parameter: R_HIP_ANGLE@RFS
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Hip Angles@RFS
 
 # max during stance
 - parameter: Left Hip Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Hip Angles, LFS, LTO]
       truncate: true
@@ -1184,7 +1184,7 @@
 
 - parameter: Right Hip Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Hip Angles, RFS, RTO]
       truncate: true
@@ -1193,7 +1193,7 @@
 # min during stance
 - parameter: Left Hip Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Hip Angles, LFS, LTO]
       truncate: true
@@ -1201,7 +1201,7 @@
 
 - parameter: Right Hip Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Hip Angles, RFS, RTO]
       truncate: true
@@ -1210,7 +1210,7 @@
 # max during stride
 - parameter: Left Hip Angles_MAX_stride
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Hip Angles, LFS, LFS]
       truncate: true
@@ -1218,7 +1218,7 @@
 
 - parameter: Right Hip Angles_MAX_stride
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Hip Angles, RFS, RFS]
       truncate: true
@@ -1229,21 +1229,21 @@
 - parameter: L_KNEE_ANG@LFS
   set: left
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Knee Angles@LFS
 
 - parameter: R_KNEE_ANG@RFS
   set: right
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Knee Angles@RFS
 
 # max during stance
 - parameter: Left Knee Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Knee Angles, LFS, LTO]
       truncate: true
@@ -1251,7 +1251,7 @@
 
 - parameter: Right Knee Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Knee Angles, RFS, RTO]
       truncate: true
@@ -1260,7 +1260,7 @@
 # min during stance
 - parameter: Left Knee Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Knee Angles, LFS, LTO]
       truncate: true
@@ -1268,7 +1268,7 @@
 
 - parameter: Right Knee Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Knee Angles, RFS, RTO]
       truncate: true
@@ -1277,7 +1277,7 @@
 # max during stride
 - parameter: Left Knee Angles_MAX
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Knee Angles, LFS, LFS]
       truncate: true
@@ -1285,7 +1285,7 @@
 
 - parameter: Right Knee Angles_MAX
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Knee Angles, RFS, RFS]
       truncate: true
@@ -1295,7 +1295,7 @@
 # max during stance
 - parameter: Left Ankle Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Ankle Angles, LFS, LTO]
       truncate: true
@@ -1303,7 +1303,7 @@
 
 - parameter: Right Ankle Angles_MAX_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Ankle Angles, RFS, RTO]
       truncate: true
@@ -1312,7 +1312,7 @@
 # min during stance
 - parameter: Left Ankle Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Ankle Angles, LFS, LTO]
       truncate: true
@@ -1320,7 +1320,7 @@
 
 - parameter: Right Ankle Angles_MIN_stance
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Ankle Angles, RFS, RTO]
       truncate: true
@@ -1329,98 +1329,98 @@
 # Foot wrt lab at footstrike
 - parameter: L_FOOT_CONTACT_ANGLE@LFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Foot Contact Angle_shifted@LFS
 
 - parameter: R_FOOT_CONTACT_ANGLE@RFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Foot Contact Angle_shifted@RFS
 
 # Time between max stride angle and max knee flexion
 - parameter: L_PEAK_KNEE_ANGLE_to_Left Stride Angle_max
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [L_peak_knee_flex, L_stride_angle_max]
 
 - parameter: R_PEAK_KNEE_ANGLE_to_Right Stride Angle_max
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [R_peak_knee_flex, R_stride_angle_max]
 
 # Time from max hip flexion to footstrike
 - parameter: L_peak_hip_flexion_cycle_to_LFS_L_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [L_peak_hip_flex, LFS]
 
 - parameter: R_peak_hip_flexion_cycle_to_RFS_R_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [R_peak_hip_flex, RFS]
 
 # Time from max knee flexion to ankle cross
 - parameter: L_PEAK_KNEE_ANGLE_to_L_Ankle_cross_L_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [L_peak_knee_flex, L_Ankle_cross]
 
 - parameter: R_PEAK_KNEE_ANGLE_to_R_Ankle_cross_R_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [R_peak_knee_flex, R_Ankle_cross]
 
 # Time from toe off to max hip flexion
 - parameter: LTO_to_L_peak_hip_flexion_L_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [LTO, L_peak_hip_flex]
 
 - parameter: RTO_to_R_peak_hip_flexion_R_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [RTO, R_peak_hip_flex]
 
 # Time from toe off to hip flexion initiation
 - parameter: LTO_to_L_peak_hip_extension_stride_L_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [LTO, L_peak_hip_extension_stride]
 
 - parameter: RTO_to_R_peak_hip_extension_stride_R_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [RTO, R_peak_hip_extension_stride]
 
 # Time from toe off to knee flexion initiation
 - parameter: LTO_to_L_peak_knee_extension_stride_L_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [LTO, L_peak_knee_extension_stride]
 
 - parameter: RTO_to_R_peak_knee_extension_stride_R_CYCLE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventDuration: [RTO, R_peak_knee_extension_stride]
 
 # Hip max extension per stride
 - parameter: Left Hip Angles_MIN_stride
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Left Hip Angles, LFS, LFS]
       truncate: true
@@ -1428,7 +1428,7 @@
 
 - parameter: Right Hip Angles_MIN_stride
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - eventMask: [Right Hip Angles, RFS, RFS]
       truncate: true
@@ -1437,7 +1437,7 @@
 # Hip angular velocity at footstrike
 - parameter: Left Hip Angles_Velocity
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - lowpass: Left Hip Angles
       extrapolate: 100
@@ -1447,7 +1447,7 @@
 
 - parameter: Right Hip Angles_Velocity
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - lowpass: Right Hip Angles
       extrapolate: 100
@@ -1457,52 +1457,52 @@
 
 - parameter: Left Hip Angles_Velocity@LFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Hip Angles_Velocity@LFS
 
 - parameter: Right Hip Angles_Velocity@RFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Hip Angles_Velocity@RFS
 
 # Hip angular velocity at midstance
 - parameter: Left Hip Angles_Velocity@L_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Hip Angles_Velocity@L_MID_STANCE
 
 - parameter: Right Hip Angles_Velocity@R_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Hip Angles_Velocity@R_MID_STANCE
 
 # Hip angular velocity at toe off
 - parameter: Left Hip Angles_Velocity@LTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Hip Angles_Velocity@LTO
 
 - parameter: Right Hip Angles_Velocity@RTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Hip Angles_Velocity@RTO
 
 # Hip angular velocity at ankle cross
 - parameter: Left Hip Angles_Velocity@L_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Hip Angles_Velocity@L_Ankle_cross
 
 - parameter: Right Hip Angles_Velocity@R_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Hip Angles_Velocity@R_Ankle_cross
 
@@ -1511,14 +1511,14 @@
 #(Left Hip Angles_MAX_stance - Left Hip Angles@LTO) / LTO_to_L_peak_hip_flexion_L_CYCLE
 - parameter: Left_hip_ang_vel_slope
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [Left Hip Angles_MAX_stance.x, Left Hip Angles.x@LTO]
     - divide: [$prev, LTO_to_L_peak_hip_flexion_L_CYCLE]
 
 - parameter: Right_hip_ang_vel_slope
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - subtract: [Right Hip Angles_MAX_stance.x, Right Hip Angles.x@RTO]
     - divide: [$prev, RTO_to_R_peak_hip_flexion_R_CYCLE]
@@ -1526,7 +1526,7 @@
 # Thigh angle at max stride angle
 - parameter: Left Thigh Angles
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: [LeftUpLeg]
       space: VirtualLab
@@ -1534,40 +1534,40 @@
 
 - parameter: Right Thigh Angles
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - jointAngle: [RightUpLeg]
       space: VirtualLab
 
 - parameter: Left Thigh Angles@Left Stride Angle_max
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Thigh Angles@L_stride_angle_max
   
 - parameter: Right Thigh Angles@Right Stride Angle_max
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Thigh Angles@R_stride_angle_max
   
   # Thigh angle at max knee flexion
 - parameter: Left Thigh Angles@L_peak_knee_flexion
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Thigh Angles@L_peak_knee_flex
 
 - parameter: Right Thigh Angles@R_peak_knee_flexion
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Thigh Angles@R_peak_knee_flex
 
 # Knee to knee separation distance at mistance
 - parameter: Knees_distance_left_stride@L_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftLeg => l_knee
       space: VirtualLab
@@ -1582,7 +1582,7 @@
 
 - parameter: Knees_distance_right_stride@R_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftLeg => l_knee
       space: VirtualLab
@@ -1598,85 +1598,85 @@
 # Knee flexion at toe off
 - parameter: Left Knee Angles@LTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Knee Angles@LTO
 
 - parameter: Right Knee Angles@RTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Knee Angles@RTO
 
 # Knee flexion at ankle cross
 - parameter: Left Knee Angles@L_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Knee Angles@L_Ankle_cross
 
 - parameter: Right Knee Angles@R_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Knee Angles@R_Ankle_cross
 
 # Knee angular velocity at footstrike
 - parameter: Left Knee Angles_Velocity@LFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Knee Angles_Velocity@LFS
   
 - parameter: Right Knee Angles_Velocity@RFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Knee Angles_Velocity@RFS
   
 # Knee angular velocity at midstance
 - parameter: Left Knee Angles_Velocity@L_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Knee Angles_Velocity@L_MID_STANCE
   
 - parameter: Right Knee Angles_Velocity@R_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Knee Angles_Velocity@R_MID_STANCE
   
 # Knee angular velocity at toe off
 - parameter: Left Knee Angles_Velocity@LTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Knee Angles_Velocity@LTO
   
 - parameter: Right Knee Angles_Velocity@RTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Knee Angles_Velocity@RTO
   
 # Knee angular velocity at ankle cross
 - parameter: Left Knee Angles_Velocity@L_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Knee Angles_Velocity@L_Ankle_cross
   
 - parameter: Right Knee Angles_Velocity@R_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Knee Angles_Velocity@R_Ankle_cross
 
 # Shank angular velocity at footstrike
 - parameter: Left Shank wrt VLab Ang Vel@LFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - angularVelocity: [VirtualLabSegment, LeftLeg, VirtualLabSegment, LeftLeg]
     - lowpass:
@@ -1688,7 +1688,7 @@
 
 - parameter: Right Shank wrt VLab Ang Vel@RFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - angularVelocity: [VirtualLabSegment, RightLeg, VirtualLabSegment, RightLeg]
     - lowpass:
@@ -1700,7 +1700,7 @@
 # Shank angular velocity at ankle cross
 - parameter: Left Shank wrt VLab Ang Vel@L_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - angularVelocity: [VirtualLabSegment, LeftLeg, VirtualLabSegment, LeftLeg]
     - lowpass:
@@ -1712,7 +1712,7 @@
 
 - parameter: Right Shank wrt VLab Ang Vel@R_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - angularVelocity: [VirtualLabSegment, RightLeg, VirtualLabSegment, RightLeg]
     - lowpass:
@@ -1724,52 +1724,52 @@
 # Ankle angular velocity at footstrike
 - parameter: Left Ankle Angles_Velocity@LFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Ankle Angles_Velocity@LFS
 
 - parameter: Right Ankle Angles_Velocity@RFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Ankle Angles_Velocity@RFS
 
 # Ankle angular velocity at midstance
 - parameter: Left Ankle Angles_Velocity@L_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Ankle Angles_Velocity@L_MID_STANCE
 
 - parameter: Right Ankle Angles_Velocity@R_MID_STANCE
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Ankle Angles_Velocity@R_MID_STANCE
 
 # Ankle angular velocity at toe off
 - parameter: Left Ankle Angles_Velocity@LTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Ankle Angles_Velocity@LTO
 
 - parameter: Right Ankle Angles_Velocity@RTO
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Ankle Angles_Velocity@RTO
 
 # Ankle angular velocity at ankle cross
 - parameter: Left Ankle Angles_Velocity@L_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Left Ankle Angles_Velocity@L_Ankle_cross
 
 - parameter: Right Ankle Angles_Velocity@R_Ankle_cross
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - import: Right Ankle Angles_Velocity@R_Ankle_cross
 
@@ -1777,7 +1777,7 @@
 # using pelvis origin instead of body COG
 - parameter: Left_Foot_Distance_to_body_COG@LFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: LeftFoot => foot
       space: VirtualLab
@@ -1792,7 +1792,7 @@
 
 - parameter: Right_Foot_Distance_to_body_COG@RFS
   where:
-    name: ^(Running|Gait)*
+    name: ^(Gait|Run|Walk)*
   steps:
     - segment: RightFoot => foot
       space: VirtualLab


### PR DESCRIPTION
This PR tries to improve consistency among measurement names across FA sessions.

* Cutting -> Cut
* Gait -> Walk
* Running -> Run
* Squatting -> Squat
* Tapping -> Tap

The pipeline is backwards compatible with the old measurement names and tested via the regression tests.
