### PR TITLE
Update templates to prevent exporting quaternions.

### DIFF
--- a/templates/fa/acc.calqulus.yaml
+++ b/templates/fa/acc.calqulus.yaml
@@ -21,7 +21,7 @@
 
 - parameter: PelvisCGPos_vel
   steps:
-    - segment: Hips_model
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
     - velocity:
     - convert: $prev
@@ -31,7 +31,7 @@
 - parameter: LFT_DistEndAcc
   set: left
   steps:
-    - segment: LeftToeBase_model
+    - vector: [LeftToeBase_model.x, LeftToeBase_model.y, LeftToeBase_model.z]
       space: VirtualLab
     - convert:
       from: mm
@@ -50,7 +50,7 @@
 - parameter: RFT_DistEndAcc
   set: right
   steps:
-    - segment: RightToeBase_model
+    - vector: [RightToeBase_model.x, RightToeBase_model.y, RightToeBase_model.z]
       space: VirtualLab
     - convert:
       from: mm
@@ -201,7 +201,7 @@
 
 - parameter: Pelvis_vel_max
   steps:
-    - segment: Hips_model
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
     - velocity:
     - magnitude:

--- a/templates/fa/cmj-sj-events-kinematics.calqulus.yaml
+++ b/templates/fa/cmj-sj-events-kinematics.calqulus.yaml
@@ -17,7 +17,7 @@
 # used by CMJ and SJ
 - parameter: RPV_CGVel
   steps:
-    - segment: Hips_model
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
     - velocity:
     - convert: $prev

--- a/templates/fa/cmj.calqulus.yaml
+++ b/templates/fa/cmj.calqulus.yaml
@@ -30,6 +30,7 @@
 
 # Flight Time
 - parameter: FlightTime_CMJ_B
+  summarize: true
   where:
     name: CMJ_B*
   steps:
@@ -310,6 +311,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -324,6 +327,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -338,6 +343,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev

--- a/templates/fa/cod.calqulus.yaml
+++ b/templates/fa/cod.calqulus.yaml
@@ -210,7 +210,7 @@
 
 - parameter: Pelvis_vel_max
   steps:
-    - segment: Hips_model
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
     - velocity:
     - magnitude:

--- a/templates/fa/dj.calqulus.yaml
+++ b/templates/fa/dj.calqulus.yaml
@@ -287,6 +287,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -301,6 +303,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -315,6 +319,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev

--- a/templates/fa/pj.calqulus.yaml
+++ b/templates/fa/pj.calqulus.yaml
@@ -292,6 +292,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -308,6 +310,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -324,6 +328,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev

--- a/templates/fa/sj.calqulus.yaml
+++ b/templates/fa/sj.calqulus.yaml
@@ -273,6 +273,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -288,6 +290,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev
@@ -303,6 +307,8 @@
     - max:
       output: hipMax
     - segment: Hips_model?name=Static* => hipsStatic
+    - vector: [hipsStatic.x, hipsStatic.y, hipsStatic.z]
+      output: hipsStatic
     - mean: hipsStatic
     - subtract: [hipMax, $prev.z]
     - convert: $prev

--- a/templates/timeseries.calqulus.yaml
+++ b/templates/timeseries.calqulus.yaml
@@ -16,7 +16,7 @@
 - parameter: LFT_DistEndAcc
   set: left
   steps:
-    - segment: LeftToeBase_model
+    - vector: [LeftToeBase_model.x, LeftToeBase_model.y, LeftToeBase_model.z]
       space: VirtualLab
     - convert:
       from: mm
@@ -35,7 +35,7 @@
 - parameter: RFT_DistEndAcc
   set: right
   steps:
-    - segment: RightToeBase_model
+    - vector: [RightToeBase_model.x, RightToeBase_model.y, RightToeBase_model.z]
       space: VirtualLab
     - convert:
       from: mm
@@ -360,10 +360,12 @@
 - parameter: Left_Knee_COM_distance
   set: left
   steps:
-    - segment: LeftLeg_model => knee
+    - vector: [LeftLeg_model.x, LeftLeg_model.y, LeftLeg_model.z]
       space: VirtualLab
-    - segment: Hips_model => pelvis
+      output: knee
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
+      output: pelvis
     - subtract: [pelvis, knee]
     - convert: 
       from: mm
@@ -372,10 +374,12 @@
 - parameter: Right_Knee_COM_distance
   set: right
   steps:
-    - segment: RightLeg_model => knee
+    - vector: [RightLeg_model.x, RightLeg_model.y, RightLeg_model.z]
       space: VirtualLab
-    - segment: Hips_model => pelvis
+      output: knee
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
+      output: pelvis
     - subtract: [pelvis, knee]
     - convert: 
       from: mm
@@ -385,10 +389,12 @@
 - parameter: Left_Ankle_COM_distance
   set: left
   steps:
-    - segment: LeftFoot_model => foot
+    - vector: [LeftFoot_model.x, LeftFoot_model.y, LeftFoot_model.z]
       space: VirtualLab
-    - segment: Hips_model => pelvis
+      output: foot
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
+      output: pelvis
     - subtract: [pelvis, foot]
     - convert: 
       from: mm
@@ -397,10 +403,12 @@
 - parameter: Right_Ankle_COM_distance
   set: right
   steps:
-    - segment: RightFoot_model => foot
+    - vector: [RightFoot_model.x, RightFoot_model.y, RightFoot_model.z]
       space: VirtualLab
-    - segment: Hips_model => pelvis
+      output: foot
+    - vector: [Hips_model.x, Hips_model.y, Hips_model.z]
       space: VirtualLab
+      output: pelvis
     - subtract: [pelvis, foot]
     - convert: 
       from: mm


### PR DESCRIPTION
This PR ensures that segment quaternions are excluded from the exported results.